### PR TITLE
[fix] Icons directory not included in package

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 include_files=(
+icons
 src
 stylesheet.css
 extension.js


### PR DESCRIPTION
#27 actually broke the close button since the new `icons` directory isn't in the list of `include_files`.